### PR TITLE
Use tab for indentation

### DIFF
--- a/go-playground.el
+++ b/go-playground.el
@@ -96,7 +96,7 @@
 package main
 
 func main() {
-  
+	
 }
 ")
     (backward-char 3)


### PR DESCRIPTION
Like `go-mode`, the snippet template should use tab for indentation instead of spaces.
