### PR TITLE
Fix a bug where starting a playground would change current directory

### DIFF
--- a/go-playground.el
+++ b/go-playground.el
@@ -106,8 +106,8 @@ environment like \"GO111MODULE=on go\")."
 			  (read-string "Go Playground filename: "))
 			 ("snippet")))
 	 (snippet-dir (go-playground-snippet-unique-dir file-name)))
-    (cd snippet-dir)
-    (shell-command go-playground-init-command)
+    (let ((default-directory snippet-dir))
+      (call-process-shell-command go-playground-init-command))
     (concat snippet-dir "/" file-name ".go")))
 
 ;


### PR DESCRIPTION
When starting a new playground, before executing the playground
initialistaion command, the current directory would be changed to the
snippet directory. This would have the side-effect of setting the
current directory of whatever buffer the user was in previously, which
could cause unexpected behaviour with other commands.

Instead of changing directory, locally bind default-directory so that
the initialisation command will be executed from the snippet directory
without an side effects.