### PR TITLE
Add go-playground-pre-rm-hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ be used such way:
 1. Set `go-playground-go-command` to "GO111MODULE=on".
 1. Set `go-playground-init-command` to "go mod init".
 
+## Using with `lsp-mode`
+If you use `lsp-mode`, you can add a hook in your init file to cleanup the workspace when a snippet
+is removed, for example:
+
+    (defun my/go-playground-remove-lsp-workspace () (when-let ((root (lsp-workspace-root))) (lsp-workspace-folders-remove root)))
+    (add-hook 'go-playground-pre-rm-hook #'my/go-playground-remove-lsp-workspace)
+
 ## Similar projects
 
 * Try [go-scratch](https://github.com/shosti/go-scratch.el) it even simplier than

--- a/go-playground.el
+++ b/go-playground.el
@@ -43,6 +43,7 @@
 (require 'gotest)
 (require 'compile)
 (require 'time-stamp)
+(require 'subr-x)
 
 (defgroup go-playground nil
   "Options specific to Go Playground."
@@ -80,6 +81,11 @@ in `go-mode`. You could use separate command specially for
 go-playground (for example run the compiler in special
 environment like \"GO111MODULE=on go\")."
   :type 'string
+  :group 'go-playground)
+
+(defcustom go-playground-pre-rm-hook nil
+  "Hook run before a snippet is removed."
+  :type 'hook
   :group 'go-playground)
 
 (defun go-playground-go ()
@@ -178,6 +184,7 @@ func main() {
 								(file-name-directory (buffer-file-name)))))
 		  (progn
 			(save-buffer)
+			(run-hooks 'go-playground-pre-rm-hook)
 			(delete-directory (file-name-directory (buffer-file-name)) t t)
 			(kill-buffer)))
 	(message "Won't delete this! Because %s is not under the path %s. Remove the snippet manually!"


### PR DESCRIPTION
This hook runs just before a snippet is deleted, to allow other
cleanup tasks such as removing the corresponding lsp-mode workspace.