### PR TITLE
add autoload to minor mode definition

### DIFF
--- a/go-playground.el
+++ b/go-playground.el
@@ -94,6 +94,7 @@ environment like \"GO111MODULE=on go\")."
   :type 'string
   :group 'go-playground)
 
+;;;###autoload
 (define-minor-mode go-playground-mode
   "A place for playing with golang code and export it in short snippets."
   :init-value nil


### PR DESCRIPTION
It can be useful for open old snippets from previous sessions. For now if I try to open snippet from previous sessions I see message `Ignoring unknown mode ‘go-playground-mode’`