### PR TITLE
fix: go-playground-upload not working in playground snippet buffers

### DIFF
--- a/go-playground.el
+++ b/go-playground.el
@@ -214,10 +214,9 @@ Tries to look for a URL at point."
 (defun go-playground-upload ()
   "Upload the current buffer to play.golang.org and return the short URL of the playground."
   (interactive)
-  (if (go-playground-inside)
-	  (goto-char (point-min))
-	(forward-line)
-	(insert (go-play-buffer))))
+  (if (not (go-playground-inside))
+      (message "Not in a Go Playground buffer!")
+    (go-play-buffer)))
 
 (defun go-playground-snippet-unique-dir (prefix)
   "Get unique directory under GOPATH/`go-playground-basedir`."
@@ -229,8 +228,10 @@ Tries to look for a URL at point."
 
 (defun go-playground-inside ()
   "Is the current buffer is valid go-playground buffer."
-  (if (string-match-p (file-truename go-playground-basedir) (file-truename (buffer-file-name)))
-	  (bound-and-true-p go-playground-mode)))
+  (and (bound-and-true-p go-playground-mode)
+       buffer-file-name
+       (string-prefix-p (file-truename go-playground-basedir)
+                        (file-truename buffer-file-name))))
 
 (provide 'go-playground)
 ;;; go-playground.el ends here


### PR DESCRIPTION
This fixes the condition in the go-playground-upload function, so it
runs go-play-buffer within go-playground snippet file buffers only.
Previously it would run it in any buffer, except snippet buffers.

I also removed the cursor movement and insertion of the result from
go-play-upload, as default behavior of go-play-buffer and go-play-region
is to place the URL on the killring, and can be customized setting the
go-play-browse-function variable.